### PR TITLE
Update to net6

### DIFF
--- a/.github/workflows/workflow-messaging.yml
+++ b/.github/workflows/workflow-messaging.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        include-prerelease: True
 
     # Format the output of dotnet format
     - name: Add dotnet-format problem matcher
@@ -56,8 +54,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        include-prerelease: True
 
     - name: Install NBGV
       run: dotnet tool update --global nbgv
@@ -109,8 +105,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        include-prerelease: True
 
     - name: dotnet nuget push
       run: dotnet nuget push ./**/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/farmerconnect/index.json"

--- a/.github/workflows/workflow-storage.yml
+++ b/.github/workflows/workflow-storage.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        include-prerelease: True
 
     # Format the output of dotnet format
     - name: Add dotnet-format problem matcher
@@ -56,8 +54,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        include-prerelease: True
 
     - name: Install NBGV
       run: dotnet tool update --global nbgv
@@ -112,8 +108,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        include-prerelease: True
 
     - name: dotnet nuget push
       run: dotnet nuget push ./**/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/farmerconnect/index.json"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <Version>3.4.244</Version>
       <PrivateAssets>all</PrivateAssets>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
     "version": "6.0",
-    "allowPrerelease": true,
     "rollForward": "latestFeature"
   }
 }

--- a/samples/Messaging/Consumer/Consumer.csproj
+++ b/samples/Messaging/Consumer/Consumer.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Messaging/Sender/Sender.csproj
+++ b/samples/Messaging/Sender/Sender.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FarmerConnect.Azure.Messaging/FarmerConnect.Azure.Messaging.csproj
+++ b/src/FarmerConnect.Azure.Messaging/FarmerConnect.Azure.Messaging.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FarmerConnect.Azure.Storage/FarmerConnect.Azure.Storage.csproj
+++ b/src/FarmerConnect.Azure.Storage/FarmerConnect.Azure.Storage.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
   </ItemGroup>


### PR DESCRIPTION
@gateixeira @thiagus 

When you update to .NET 6 you also have to update the packages, not just the TargetFramework, as I mentioned in this bug #17.