### PR TITLE
Messaging over Azure Storage Queues

### DIFF
--- a/samples/Messaging/Consumer/Program.cs
+++ b/samples/Messaging/Consumer/Program.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FarmerConnect.Azure.Messaging;
-using FarmerConnect.Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -25,27 +24,34 @@ namespace Consumer
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddLogging(configure => configure.AddConsole());
+                    services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
                     services.AddScoped<AcceptEventHandler>();
+                    services.AddScoped<SecondAcceptEventHandler>();
 
-                    services.AddMessagingConsumer(options =>
+                    //services.AddServiceBusConsumer(options =>
+                    //{
+                    //    options.ConnectionString = hostContext.Configuration["Messaging:ConnectionString"];
+                    //    options.QueueName = hostContext.Configuration["Messaging:QueueName"];
+                    //});
+
+                    services.AddStorageQueueConsumer(options =>
                     {
-                        options.ConnectionString = hostContext.Configuration["AzureServiceBus:ConnectionString"];
-                        options.QueueName = hostContext.Configuration["AzureServiceBus:QueueName"];
+                        options.ConnectionString = hostContext.Configuration["Messaging:ConnectionString"];
+                        options.QueueName = hostContext.Configuration["Messaging:QueueName"];
                     });
 
-                    services.AddHostedService<EventBusRegistrationBackgroundService>();
+                    services.AddHostedService<EventRegistrationBackgroundService>();
                 })
                 .RunConsoleAsync();
         }
 
-        public class EventBusRegistrationBackgroundService : IHostedService
+        public class EventRegistrationBackgroundService : IHostedService
         {
-            private readonly EventBusSubscriptionManager _subscriptionManager;
-            private readonly ILogger<EventBusRegistrationBackgroundService> _logger;
+            private readonly EventSubscriptionManager _subscriptionManager;
+            private readonly ILogger<EventRegistrationBackgroundService> _logger;
 
-            public EventBusRegistrationBackgroundService(EventBusSubscriptionManager subscriptionManager, ILogger<EventBusRegistrationBackgroundService> logger)
+            public EventRegistrationBackgroundService(EventSubscriptionManager subscriptionManager, ILogger<EventRegistrationBackgroundService> logger)
             {
                 _subscriptionManager = subscriptionManager;
                 _logger = logger;
@@ -54,6 +60,7 @@ namespace Consumer
             public Task StartAsync(CancellationToken cancellationToken)
             {
                 _subscriptionManager.Subscribe<AcceptEvent, AcceptEventHandler>();
+                _subscriptionManager.Subscribe<AcceptEvent, SecondAcceptEventHandler>();
 
                 _logger.LogInformation("Completed event handler registration");
 
@@ -87,6 +94,25 @@ namespace Consumer
                 _logger.LogInformation("Doing the stuff for {TransactionId}...", integrationEvent.TransactionId);
                 await Task.Delay(TimeSpan.FromSeconds(3));
                 _logger.LogInformation("...finished the stuff.");
+            }
+        }
+
+        public class SecondAcceptEventHandler : IIntegrationEventHandler
+        {
+            private readonly ILogger<SecondAcceptEventHandler> _logger;
+
+            public SecondAcceptEventHandler(ILogger<SecondAcceptEventHandler> logger)
+            {
+                _logger = logger;
+            }
+
+            public async Task Handle(object @event)
+            {
+                var integrationEvent = (AcceptEvent)@event;
+
+                _logger.LogInformation("Doing other stuff for {TransactionId}...", integrationEvent.TransactionId);
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                _logger.LogInformation("...finished the other stuff.");
             }
         }
     }

--- a/samples/Messaging/Consumer/Program.cs
+++ b/samples/Messaging/Consumer/Program.cs
@@ -39,6 +39,8 @@ namespace Consumer
                     {
                         options.ConnectionString = hostContext.Configuration["Messaging:ConnectionString"];
                         options.QueueName = hostContext.Configuration["Messaging:QueueName"];
+                        //options.MaxMessages = 1;
+                        // options.MaxPollingInterval = 1000;
                     });
 
                     services.AddHostedService<EventRegistrationBackgroundService>();

--- a/samples/Messaging/Sender/Program.cs
+++ b/samples/Messaging/Sender/Program.cs
@@ -65,7 +65,7 @@ namespace Sender
                 {
                     TransactionId = Guid.NewGuid().ToString()
                 };
-                await _queueSender.SendMessage(@event, cancellationToken);
+                await _queueSender.SendMessageAsync(@event, cancellationToken);
 
                 await Task.Delay(TimeSpan.FromMilliseconds(1400), cancellationToken);
             }

--- a/samples/Messaging/Sender/Program.cs
+++ b/samples/Messaging/Sender/Program.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FarmerConnect.Azure.Messaging;
-using FarmerConnect.Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/FarmerConnect.Azure.Messaging/.vscode/tasks.json
+++ b/src/FarmerConnect.Azure.Messaging/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/FarmerConnect.Azure.Messaging/EventSubscriptionManager.cs
+++ b/src/FarmerConnect.Azure.Messaging/EventSubscriptionManager.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace FarmerConnect.Azure.Messaging.ServiceBus
+namespace FarmerConnect.Azure.Messaging
 {
-    public class EventBusSubscriptionManager
+    public class EventSubscriptionManager
     {
         private readonly Dictionary<string, List<Type>> _handlers = new();
         private readonly List<Type> _eventTypes = new();

--- a/src/FarmerConnect.Azure.Messaging/FarmerConnect.Azure.Messaging.csproj
+++ b/src/FarmerConnect.Azure.Messaging/FarmerConnect.Azure.Messaging.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.3" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.10.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FarmerConnect.Azure.Messaging/IIntegrationEventHandler.cs
+++ b/src/FarmerConnect.Azure.Messaging/IIntegrationEventHandler.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace FarmerConnect.Azure.Messaging.ServiceBus
+namespace FarmerConnect.Azure.Messaging
 {
     public interface IIntegrationEventHandler
     {

--- a/src/FarmerConnect.Azure.Messaging/IQueueSender.cs
+++ b/src/FarmerConnect.Azure.Messaging/IQueueSender.cs
@@ -5,6 +5,6 @@ namespace FarmerConnect.Azure.Messaging
 {
     public interface IQueueSender
     {
-        Task SendMessage(IntegrationEvent @event, CancellationToken cancellationToken = default);
+        Task SendMessageAsync(IntegrationEvent @event, CancellationToken cancellationToken = default);
     }
 }

--- a/src/FarmerConnect.Azure.Messaging/IQueueSender.cs
+++ b/src/FarmerConnect.Azure.Messaging/IQueueSender.cs
@@ -1,9 +1,9 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 
-namespace FarmerConnect.Azure.Messaging.ServiceBus
+namespace FarmerConnect.Azure.Messaging
 {
-    public interface IServiceBusQueueSender
+    public interface IQueueSender
     {
         Task SendMessage(IntegrationEvent @event, CancellationToken cancellationToken = default);
     }

--- a/src/FarmerConnect.Azure.Messaging/IntegrationEvent.cs
+++ b/src/FarmerConnect.Azure.Messaging/IntegrationEvent.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.Json.Serialization;
 
-namespace FarmerConnect.Azure.Messaging.ServiceBus
+namespace FarmerConnect.Azure.Messaging
 {
     public abstract class IntegrationEvent
     {

--- a/src/FarmerConnect.Azure.Messaging/MessagingOptions.cs
+++ b/src/FarmerConnect.Azure.Messaging/MessagingOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace FarmerConnect.Azure.Messaging
+{
+    public class MessagingOptions
+    {
+        public string ConnectionString { get; set; }
+        public string QueueName { get; set; }
+        public int MaxMessages { get; set; } = 1; // Maximum number of messages to receive at once. If set to one then the behaviour is more similar to the service bus implementation with pub / sub.
+        public int MaxPollingInterval { get; set; } = 51200; // This is the maximum polling interval. Since we pay connections to the storage account this could lead to unwanted cost if not high enough.
+    }
+}

--- a/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusHostedService.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusHostedService.cs
@@ -6,13 +6,13 @@ using Microsoft.Extensions.Logging;
 
 namespace FarmerConnect.Azure.Messaging.ServiceBus
 {
-    public class ServiceBusQueueConsumerBackgroundService : IHostedService, IDisposable
+    public class ServiceBusHostedService : IHostedService, IDisposable
     {
         private bool _disposedValue;
-        private readonly ILogger<ServiceBusQueueConsumerBackgroundService> _logger;
+        private readonly ILogger<ServiceBusHostedService> _logger;
         private readonly ServiceBusQueueConsumer _serviceBusQueueConsumer;
 
-        public ServiceBusQueueConsumerBackgroundService(ServiceBusQueueConsumer serviceBusQueueConsumer, ILogger<ServiceBusQueueConsumerBackgroundService> logger)
+        public ServiceBusHostedService(ServiceBusQueueConsumer serviceBusQueueConsumer, ILogger<ServiceBusHostedService> logger)
         {
             _serviceBusQueueConsumer = serviceBusQueueConsumer;
             _logger = logger;

--- a/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueConsumer.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueConsumer.cs
@@ -11,15 +11,15 @@ namespace FarmerConnect.Azure.Messaging.ServiceBus
 {
     public class ServiceBusQueueConsumer
     {
-        private readonly EventBusSubscriptionManager _subscriptionManager;
+        private readonly EventSubscriptionManager _subscriptionManager;
         private readonly IServiceProvider _serviceProvider;
-        private readonly ServiceBusOptions _options;
+        private readonly MessagingOptions _options;
         private readonly ServiceBusClient _client;
         private readonly ILogger _logger;
         private ServiceBusProcessor _processor;
         private const string INTEGRATION_EVENT_SUFFIX = "Event";
 
-        public ServiceBusQueueConsumer(EventBusSubscriptionManager subscriptionManager, IServiceProvider serviceProvider, IOptions<ServiceBusOptions> options, ILogger<ServiceBusQueueConsumer> logger)
+        public ServiceBusQueueConsumer(EventSubscriptionManager subscriptionManager, IServiceProvider serviceProvider, IOptions<MessagingOptions> options, ILogger<ServiceBusQueueConsumer> logger)
         {
             _subscriptionManager = subscriptionManager;
             _serviceProvider = serviceProvider;

--- a/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueSender.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueSender.cs
@@ -9,14 +9,14 @@ using Microsoft.Extensions.Options;
 
 namespace FarmerConnect.Azure.Messaging.ServiceBus
 {
-    public class ServiceBusQueueSender : IServiceBusQueueSender
+    public class ServiceBusQueueSender : IQueueSender
     {
-        private readonly ServiceBusOptions _options;
+        private readonly MessagingOptions _options;
         private readonly ServiceBusClient _client;
         private readonly ILogger<ServiceBusQueueConsumer> _logger;
         private const string INTEGRATION_EVENT_SUFFIX = "Event";
 
-        public ServiceBusQueueSender(IOptions<ServiceBusOptions> options, ILogger<ServiceBusQueueConsumer> logger)
+        public ServiceBusQueueSender(IOptions<MessagingOptions> options, ILogger<ServiceBusQueueConsumer> logger)
         {
             _options = options.Value;
             _logger = logger;

--- a/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueSender.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueSender.cs
@@ -37,7 +37,7 @@ namespace FarmerConnect.Azure.Messaging.ServiceBus
                 Subject = eventName
             }, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("Successfully added message to queue: {QueueName}", _options.QueueName);
+            _logger.LogDebug("Successfully added message to queue: {QueueName}", _options.QueueName);
         }
     }
 }

--- a/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueSender.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceBus/ServiceBusQueueSender.cs
@@ -24,7 +24,7 @@ namespace FarmerConnect.Azure.Messaging.ServiceBus
             _client = new ServiceBusClient(_options.ConnectionString);
         }
 
-        public async Task SendMessage(IntegrationEvent @event, CancellationToken cancellationToken = default)
+        public async Task SendMessageAsync(IntegrationEvent @event, CancellationToken cancellationToken = default)
         {
             var eventName = @event.GetType().Name.Replace(INTEGRATION_EVENT_SUFFIX, "");
             var jsonMessage = JsonSerializer.Serialize(@event, @event.GetType());

--- a/src/FarmerConnect.Azure.Messaging/ServiceBusOptions.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceBusOptions.cs
@@ -1,6 +1,6 @@
-﻿namespace FarmerConnect.Azure.Messaging.ServiceBus
+﻿namespace FarmerConnect.Azure.Messaging
 {
-    public class ServiceBusOptions
+    public class MessagingOptions
     {
         public string ConnectionString { get; set; }
         public string QueueName { get; set; }

--- a/src/FarmerConnect.Azure.Messaging/ServiceBusOptions.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceBusOptions.cs
@@ -1,8 +1,0 @@
-﻿namespace FarmerConnect.Azure.Messaging
-{
-    public class MessagingOptions
-    {
-        public string ConnectionString { get; set; }
-        public string QueueName { get; set; }
-    }
-}

--- a/src/FarmerConnect.Azure.Messaging/ServiceCollectionExtensions.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceCollectionExtensions.cs
@@ -6,22 +6,22 @@ namespace FarmerConnect.Azure.Messaging
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddMessagingConsumer(this IServiceCollection services, Action<ServiceBusOptions> setupAction)
+        public static IServiceCollection AddServiceBusConsumer(this IServiceCollection services, Action<MessagingOptions> setupAction)
         {
             services.Configure(setupAction);
 
             services.AddSingleton<ServiceBusQueueConsumer>();
-            services.AddSingleton<EventBusSubscriptionManager>();
+            services.AddSingleton<EventSubscriptionManager>();
             services.AddHostedService<ServiceBusQueueConsumerBackgroundService>();
 
             return services;
         }
 
-        public static IServiceCollection AddMessagingSender(this IServiceCollection services, Action<ServiceBusOptions> setupAction)
+        public static IServiceCollection AddServiceBusSender(this IServiceCollection services, Action<MessagingOptions> setupAction)
         {
             services.Configure(setupAction);
 
-            services.AddSingleton<IServiceBusQueueSender, ServiceBusQueueSender>();
+            services.AddSingleton<IQueueSender, ServiceBusQueueSender>();
 
             return services;
         }

--- a/src/FarmerConnect.Azure.Messaging/ServiceCollectionExtensions.cs
+++ b/src/FarmerConnect.Azure.Messaging/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FarmerConnect.Azure.Messaging.ServiceBus;
+using FarmerConnect.Azure.Messaging.StorageQueue;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FarmerConnect.Azure.Messaging
@@ -12,7 +13,7 @@ namespace FarmerConnect.Azure.Messaging
 
             services.AddSingleton<ServiceBusQueueConsumer>();
             services.AddSingleton<EventSubscriptionManager>();
-            services.AddHostedService<ServiceBusQueueConsumerBackgroundService>();
+            services.AddHostedService<ServiceBusHostedService>();
 
             return services;
         }
@@ -22,6 +23,25 @@ namespace FarmerConnect.Azure.Messaging
             services.Configure(setupAction);
 
             services.AddSingleton<IQueueSender, ServiceBusQueueSender>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddStorageQueueConsumer(this IServiceCollection services, Action<MessagingOptions> setupAction)
+        {
+            services.Configure(setupAction);
+
+            services.AddSingleton<EventSubscriptionManager>();
+            services.AddHostedService<StorageQueueConsumer>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddStorageQueueSender(this IServiceCollection services, Action<MessagingOptions> setupAction)
+        {
+            services.Configure(setupAction);
+
+            services.AddSingleton<IQueueSender, StorageQueueSender>();
 
             return services;
         }

--- a/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
+++ b/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
@@ -89,6 +89,8 @@ namespace FarmerConnect.Azure.Messaging.StorageQueue
                         {
                             await queue.DeleteMessageAsync(message.MessageId, message.PopReceipt, stoppingToken);
                         }
+
+                        await Task.Delay(100, stoppingToken);
                     }
                 }
                 else

--- a/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
+++ b/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
@@ -1,12 +1,12 @@
-﻿using System.Threading;
+﻿using System;
+using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Azure.Storage.Queues;
-using System.Text.Json;
-using System;
 
 namespace FarmerConnect.Azure.Messaging.StorageQueue
 {

--- a/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
+++ b/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
@@ -17,9 +17,6 @@ namespace FarmerConnect.Azure.Messaging.StorageQueue
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<StorageQueueConsumer> _logger;
 
-        private const int MaxPollingInterval = 51200; // This is the maximum polling interval. Since we pay connections to the storage account this could lead to unwanted cost if not high enough.
-        private const int MaxMessages = 1; // Maximum number of messages to receive at once. If set to one then the behaviour is more similar to the service bus implementation with pub / sub.
-
         public StorageQueueConsumer(EventSubscriptionManager subscriptionManager, IOptionsSnapshot<MessagingOptions> options, IServiceProvider serviceProvider, ILogger<StorageQueueConsumer> logger)
         {
             _subscriptionManager = subscriptionManager;
@@ -44,7 +41,7 @@ namespace FarmerConnect.Azure.Messaging.StorageQueue
                 // After subsequent failed attempts to get a queue message, the wait time continues to increase until it reaches the maximum wait time, which defaults to one minute.
                 // The maximum wait time is configurable via the maxPollingInterval property in the host.json file.
 
-                var messages = queue.ReceiveMessages(MaxMessages, cancellationToken: stoppingToken).Value;
+                var messages = queue.ReceiveMessages(_options.MaxMessages, cancellationToken: stoppingToken).Value;
                 if (messages.Length > 0)
                 {
                     _logger.LogDebug("We have some new messages, let's process them");
@@ -95,7 +92,7 @@ namespace FarmerConnect.Azure.Messaging.StorageQueue
                 }
                 else
                 {
-                    if (waitTime < MaxPollingInterval)
+                    if (waitTime < _options.MaxPollingInterval)
                     {
                         waitTime *= 2;
                     }

--- a/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
+++ b/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueConsumer.cs
@@ -1,0 +1,106 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Azure.Storage.Queues;
+using System.Text.Json;
+using System;
+
+namespace FarmerConnect.Azure.Messaging.StorageQueue
+{
+    public class StorageQueueConsumer : BackgroundService
+    {
+        private readonly EventSubscriptionManager _subscriptionManager;
+        private readonly MessagingOptions _options;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<StorageQueueConsumer> _logger;
+
+        private const int MaxPollingInterval = 51200; // This is the maximum polling interval. Since we pay connections to the storage account this could lead to unwanted cost if not high enough.
+        private const int MaxMessages = 1; // Maximum number of messages to receive at once. If set to one then the behaviour is more similar to the service bus implementation with pub / sub.
+
+        public StorageQueueConsumer(EventSubscriptionManager subscriptionManager, IOptionsSnapshot<MessagingOptions> options, IServiceProvider serviceProvider, ILogger<StorageQueueConsumer> logger)
+        {
+            _subscriptionManager = subscriptionManager;
+            _options = options.Value;
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var queue = new QueueClient(_options.ConnectionString, _options.QueueName);
+            await queue.CreateIfNotExistsAsync(cancellationToken: stoppingToken);
+
+            var waitTime = 100;
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("Checking for new messages...");
+
+                // When a message is found, the runtime waits 100 milliseconds and then checks for another message
+                // When no message is found, it waits about 200 milliseconds before trying again.
+                // After subsequent failed attempts to get a queue message, the wait time continues to increase until it reaches the maximum wait time, which defaults to one minute.
+                // The maximum wait time is configurable via the maxPollingInterval property in the host.json file.
+
+                var messages = queue.ReceiveMessages(MaxMessages, cancellationToken: stoppingToken).Value;
+                if (messages.Length > 0)
+                {
+                    _logger.LogDebug("We have some new messages, let's process them");
+                    waitTime = 100;
+
+                    foreach (var message in messages)
+                    {
+                        try
+                        {
+                            var jsonDocument = JsonDocument.Parse(message.Body);
+
+                            var eventName = jsonDocument.RootElement.GetProperty("eventName").GetString();
+                            var eventType = _subscriptionManager.GetEventTypeByName(eventName);
+                            var messageData = jsonDocument.RootElement.GetProperty("data").GetString();
+
+                            var integrationEvent = JsonSerializer.Deserialize(messageData, eventType, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+                            using (var scope = _serviceProvider.CreateScope())
+                            {
+                                var eventHandlerTypes = _subscriptionManager.GetHandlersForEvent(eventName);
+
+                                foreach (var handler in eventHandlerTypes)
+                                {
+                                    var eventHandler = scope.ServiceProvider.GetService(handler);
+                                    if (eventHandler == null)
+                                    {
+                                        _logger.LogWarning("Unable to find registered service for: {EventHandler}", handler.Name);
+                                        continue;
+                                    }
+
+                                    var concreteType = (IIntegrationEventHandler)scope.ServiceProvider.GetService(handler);
+                                    await concreteType.Handle(integrationEvent).ConfigureAwait(false);
+                                }
+                            }
+
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Unable to process message: {MessageBody}", message.Body);
+                        }
+                        finally
+                        {
+                            await queue.DeleteMessageAsync(message.MessageId, message.PopReceipt, stoppingToken);
+                        }
+                    }
+                }
+                else
+                {
+                    if (waitTime < MaxPollingInterval)
+                    {
+                        waitTime *= 2;
+                    }
+                    _logger.LogDebug("No new message was received. Increasing the polling wait timer to {WaitTimeInMs}ms", waitTime);
+                    await Task.Delay(waitTime, stoppingToken);
+                }
+            }
+        }
+    }
+}

--- a/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueSender.cs
+++ b/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueSender.cs
@@ -18,7 +18,7 @@ namespace FarmerConnect.Azure.Messaging.StorageQueue
             _options = options.Value;
         }
 
-        public async Task SendMessage(IntegrationEvent @event, CancellationToken cancellationToken = default)
+        public async Task SendMessageAsync(IntegrationEvent @event, CancellationToken cancellationToken = default)
         {
             var queue = new QueueClient(_options.ConnectionString, _options.QueueName);
             await queue.CreateIfNotExistsAsync(cancellationToken: cancellationToken);

--- a/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueSender.cs
+++ b/src/FarmerConnect.Azure.Messaging/StorageQueue/StorageQueueSender.cs
@@ -1,0 +1,39 @@
+﻿using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FarmerConnect.Azure.Messaging.StorageQueue
+{
+    public class StorageQueueSender : IQueueSender
+    {
+        private readonly ILogger<StorageQueueSender> _logger;
+        private readonly MessagingOptions _options;
+
+        public StorageQueueSender(IOptionsSnapshot<MessagingOptions> options, ILogger<StorageQueueSender> logger)
+        {
+            _logger = logger;
+            _options = options.Value;
+        }
+
+        public async Task SendMessage(IntegrationEvent @event, CancellationToken cancellationToken = default)
+        {
+            var queue = new QueueClient(_options.ConnectionString, _options.QueueName);
+            await queue.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+            var eventName = @event.GetType().Name;
+
+            var message = JsonSerializer.Serialize(new
+            {
+                EventName = eventName,
+                Data = JsonSerializer.Serialize(@event, @event.GetType(), new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })
+            }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+            await queue.SendMessageAsync(message, cancellationToken);
+
+            _logger.LogDebug("Successfully added message to queue: {QueueName}", _options.QueueName);
+        }
+    }
+}

--- a/src/FarmerConnect.Azure.Messaging/version.json
+++ b/src/FarmerConnect.Azure.Messaging/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.1",
+  "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
## Changes in this pull request:

We are using Azure Service Bus for messaging when the services are deployed to AKS. Service bus has many benefits over storage queues. One being that it supports the publish / subscribe pattern. Storage queues are simple queues that require a consumer to be polling for new messages. This is not suitable for a messaging type of implementation. Yet there is no emulator for the Azure service bus like there is for the storage queues with `Azurite`.

To have messaging running locally with Azure service bus each dev running the applications would require a separate queue on the service bus namespace. This does not scale and can result in strange behaviors.

This is the reason I implemented the messaging with storage queues that can be used for local development.

You must run `azurite` on your dev machine so that this works and update the settings to:

```
"Messaging": {
        "ConnectionString": "UseDevelopmentStorage=true",
        "QueueName": "test-queue"
    }
```

The connection string becomes very simple :-)

⚠️ This has breaking changes!

FYI: @328d95 @farmerconnect/poatek 